### PR TITLE
Fixed issue on updating matrix choice

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ main.o: main.cpp strategy.h matrix.h reduce.h
 strategy.o: strategy.cpp matrix.h
 	g++ -O3 -c strategy.cpp -lpthread
 matrix.o: matrix.cpp
-	g++ -O3 -c matrix.cpp matrix.h -lpthread
+	g++ -O3 -c matrix.cpp -lpthread
 reduce.o:reduce.cpp strategy.h matrix.h
 	g++ -O3 -c reduce.cpp -lpthread
 


### PR DESCRIPTION
Fixed issue where `matrix.h` was unnecessarily precompiled to `matrix.h.gch`, which did not get cleaned and updated on changing the preprocessor macro `CHOICE`, causing the previous matrix to be executed.